### PR TITLE
Several fixes for Julia 0.7

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using Matcha
 using Base.Test
+import Base: LabelNode, GotoNode
 
 # strings
 x = "hey 1yo whatup?"


### PR DESCRIPTION
A couple of fixes for Julia 0.7 (compatible with Julia 0.6): 

1. `SubString(s, a,  b)` may fail if `a` or `b` fall into unicode char continuation. For example, try this on Julia 0.7: 

```
x = "(ɔ◔‿◔)ɔ ♥ (⊙.⊙(☉̃ₒ☉)⊙.⊙)"
x[3]                         # StringIndexError
SubString(x[2:3])    # StringIndexError
```

`safe_substring` moves `a` forward and `b` backward until they become valid UTF8 chars (beginning of the char), which mimics Julia 0.6 behavior. 

2. `.indexes` field of `SubArray` is renamed to `indices`. `parentindices` can be used in Julia 0.7, so I added it to Julia 0.6 as well (FemtoCleaner should remove it once support for 0.6 is dropped).

3. `LabelNode`, `GotoNode` and a number of other names need to be explicitly exported from Base. 

Unfortunately, these aren't all needed fixes: many tests still fail for matching rules and I don't have enough knowledge of Matcha to really figure out what's going wrong. 