### PR TITLE
Updated to work with v0.7+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
   - linux
   - osx
 julia:
-  - 0.6
+  - 0.7
   - nightly
 
 notifications:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,1 @@
-julia 0.6
+julia 0.7

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.7/julia-0.7-latest-win32.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.7/julia-0.7-latest-win64.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
 

--- a/src/Matcha.jl
+++ b/src/Matcha.jl
@@ -1,7 +1,15 @@
 __precompile__(true)
 module Matcha
 
-import Base: tail, @pure
+import Base: firstindex, iterate, tail, @pure
+
+# NOTE Debug flag will print braching & states
+#      Used for branching comparison with code for v0.6
+debug = false
+
+export matchat, matchone, matchitall, matchreplace
+export anything
+export Greed
 
 abstract type MatchSteering end
 struct Greed{F, T} <: MatchSteering
@@ -15,6 +23,8 @@ Greed(x::F) where {F} = Greed(x, 1:typemax(Int))
 greediness(x) = 1:1
 greediness(x::Greed) = x.range
 
+alwaysmatch(x) = true
+const anything = Greed(alwaysmatch)
 
 trymatch(ms::MatchSteering, val, history) = trymatch(ms.x, val, history)
 function trymatch(f::Function, val, history)
@@ -54,8 +64,16 @@ end
 """
 Function that walks through `list` and saves `elem` in some way
 """
-function Base.next(history::History, list, state)
-    elem, state = next(list, state)
+done(x, i) = true
+function done(x::T, i::I) where {T<:AbstractString, I<:Integer}
+    i > ncodeunits(x)
+end
+function done(x::T, i::I) where {T<:AbstractArray, I<:Integer} 
+    !isassigned(x, i) && i == length(x)+1
+end
+
+function Base.iterate(history::History, list, state)
+    elem, state = iterate(list, state)
     if needs_recording(history)
         push!(history.buffer, elem)
     end
@@ -93,15 +111,27 @@ function start_match(history, state)
 end
 
 function inner_matchat(
-        list, last_state,
+        list, 
+        last_state,
         patterns::NTuple{N, Any},
         history = History(list, last_state)
     ) where N
-    done(list, last_state) && return false, history, last_state, 0
-    matches = 0; lastmatchstate = last_state
+
+    debug && println("-- inner_matchat --")
+    debug && println(list, " - ", last_state)
+    debug && println(patterns)
+
+    if done(list, last_state)
+        return false, history, last_state, 0
+    end
+
+    matches = 0
+    lastmatchstate = last_state
+
     start_match(history, last_state)
-    elem, state = next(history, list, last_state)
+    elem, state = iterate(history, list, last_state)
     pattern = patterns[1]
+
     while true
         # greed can make one fail, but it depends on the circumstances
         greedrange = greediness(pattern)
@@ -110,13 +140,19 @@ function inner_matchat(
         # okay lets get matchin'
         matched = trymatch(pattern, elem, history)
 
+        debug && println("matched = ", matched)
+        debug && println("enough = ", enough)
+
         if matched
             matches += 1
             lastmatchstate = last_state
+            debug && println(">> A")
         else
             # we don't have enough matches yet to fail matching, or we don't have any more patterns to match
             if !enough || N == 1
-                return finish_match(enough, history, enough ? lastmatchstate : state)..., matches # we fail or not, depending whether we have enough
+                # we fail or not, depending whether we have enough
+                debug && println(">> B1")
+                return finish_match(enough, history, enough ? lastmatchstate : state)..., matches 
             end
             if N > 1
                 # okay, we failed but already have enough.
@@ -125,6 +161,7 @@ function inner_matchat(
                 if matches > 0
                     finish_match(true, history, lastmatchstate)
                 end
+                debug && println(">> B2")
                 return inner_matchat(list, last_state, tail(patterns), history)
             end
         end
@@ -136,6 +173,7 @@ function inner_matchat(
             # this is where a match of the next pattern could end things!
             if matches == last(greedrange) # we actually are at the last allowed
                 finish_match(true, history, lastmatchstate)
+                debug && println(">> C1")
                 return inner_matchat(list, state, tail(patterns), history)
             else
                 # a copy of history is needed, since we can backtrack
@@ -143,11 +181,15 @@ function inner_matchat(
                 finish_match(true, newbranch, lastmatchstate - 1)
                 ismatch, history2, state2, n = inner_matchat(list, last_state, tail(patterns), newbranch)
                 (ismatch && n > 0) && return true, history2, state2, matches
+                debug && println(">> C2")
             end
         elseif N == 1 && matches == last(greedrange) # rest is empty and we have enough -> stop!
             res = finish_match(true, history, lastmatchstate)
+            debug && println(">> C3")
             return res..., matches
         end
+
+        debug && println(done(list, state))
 
         # we matched!
         # But if we have enough and the next pattern starts matching, we must stop here
@@ -155,22 +197,29 @@ function inner_matchat(
             # this madness is over!
             # if succesfull or not depends on whether we have enough and no rest!
             success = enough && (N == 1 || all(x-> 0 in greediness(x), tail(patterns)))
+            debug && println(">> D1")
             return finish_match(success, history, success ? lastmatchstate : state)..., matches
         end
         # okay, we're here, meaning we matched in some way and can continue making history!
-        last_state = state;
-        elem, state = next(history, list, last_state)
+        last_state = state
+
+        debug && println(">> E")
+
+        elem, state = iterate(history, list, last_state)
     end
     return false, history, last_state, matches # should be dead code
 end
 
 function matchat(
-        list, patterns::Tuple,
+        list, 
+        patterns::Tuple,
     )
-    matchat(list, start(list), patterns)
+    matchat(list, firstindex(list), patterns)
 end
 function matchat(
-        list, state, patterns::Tuple,
+        list, 
+        state, 
+        patterns::Tuple,
     )
     history = History(list, state)
     matched, hist, state, n = inner_matchat(
@@ -180,32 +229,38 @@ function matchat(
 end
 
 function matchone(
-        list, patterns::Tuple,
+        list, 
+        patterns::Tuple,
     )
-    matchone(list, start(list), patterns)
+    matchone(list, firstindex(list), patterns)
 end
 function matchone(
-        list, state, patterns::Tuple,
+        list, 
+        state, 
+        patterns::Tuple,
     )
     history = History(list, state)
     while !done(list, state)
         history = History(list, state)
         match, history, _, n = inner_matchat(list, state, patterns, history)
         match && return true, history.matches
-        elem, state = next(list, state)
+        elem, state = iterate(list, state)
     end
     return false, history.matches
 end
 
 function matchitall(
-        list, patterns::Tuple,
+        list, 
+        patterns::Tuple,
     )
-    matchitall(list, start(list), patterns)
+    matchitall(list, firstindex(list), patterns)
 end
 
 # TODO find better non clashing name with Base
 function matchitall(
-        list, state, patterns::Tuple,
+        list, 
+        state, 
+        patterns::Tuple,
     )
     history = History(list, state)
     matches = typeof(history.matches)[]
@@ -215,7 +270,7 @@ function matchitall(
         if match
             push!(matches, history.matches)
         end
-        elem, state = next(list, state)
+        elem, state = iterate(list, state)
     end
     return matches
 end
@@ -223,16 +278,13 @@ end
 function forward(x, elem, state, n)
     for i=1:n
         done(x, state) && break
-        elem, state = next(x, state)
+        elem, state = iterate(x, state)
     end
     elem, state
 end
+
 slength(x::Union{Tuple, AbstractArray}) = length(x)
 slength(x) = 1
-
-if VERSION < v"0.7.0-DEV.3020"
-    parentindices(v::SubArray) = v.indexes
-end
 
 @inline firstindex(v::SubArray) = parentindices(v)[1][1]
 @inline firstindex(v::Union{Vector, Tuple}) = firstindex(first(v))
@@ -244,11 +296,11 @@ function matchreplace(f, list, patterns)
     matches = matchitall(list, patterns)
     isempty(matches) && return copy(list)
     result = similar(list, 0)
-    state, i = start(list), 1
+    state, i = firstindex(list), 1
     cmatch = matches[i]
     while !done(list, state)
         last_state = state
-        elem, state = next(list, state)
+        elem, state = iterate(list, state)
         isreplace = i <= length(matches) && last_state == firstindex(cmatch)
         replacements, n = if isreplace
             i += 1
@@ -275,6 +327,9 @@ function matchreplace(f, list::AbstractVector, patterns)
     isempty(matches) && return copy(list)
     result = similar(list, 0)
     lastidx = 1
+
+    debug && println(matches)
+
     for cmatch in matches
         a, b = firstindex(cmatch), lastindex(cmatch)
         N =  sum(map(slength, cmatch))
@@ -289,13 +344,5 @@ function matchreplace(f, list::AbstractVector, patterns)
     append!(result, @view list[lastidx:end])
     result
 end
-
-alwaysmatch(x) = true
-const anything = Greed(alwaysmatch)
-
-export matchat, matchone, matchitall, matchreplace
-export Greed
-export anything
-
 
 end # module

--- a/test/expr_match_test.jl
+++ b/test/expr_match_test.jl
@@ -1,3 +1,8 @@
+# Simulated 'LabelNode' for compatibility
+struct LabelNode <: Any
+    label::Int64
+end
+
 # Test for history and matchreplace
 isunless(x::Expr) = x.head == :gotoifnot
 isunless(x) = false

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,4 @@
-#include("../src/Matcha.jl")
-#using .Matcha
 using Matcha
-
 using Test
 # NOTE v0.7+ LabelNode missing
 import Base: GotoNode, SlotNumber, SSAValue, NewvarNode

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,14 +1,18 @@
+#include("../src/Matcha.jl")
+#using .Matcha
 using Matcha
-using Base.Test
-import Base: LabelNode, GotoNode, SlotNumber, SSAValue, NewvarNode
+
+using Test
+# NOTE v0.7+ LabelNode missing
+import Base: GotoNode, SlotNumber, SSAValue, NewvarNode
 
 # strings
 x = "hey 1yo whatup?"
 
 matched, matches = matchat(x, (
-    Greed(x-> x in ('h', 'y', 'e'), 3:3),
+    Greed(x -> x in ('h', 'y', 'e'), 3:3),
     ' ',
-    isnumber
+    isnumeric
 ))
 
 @test matches == [SubString(x, 1, 3), SubString(x, 4, 4), SubString(x, 5, 5)]
@@ -27,6 +31,7 @@ x = [1,2,3,4,5,6]
 test1(x) = x == 2
 test2(x) = x == 3
 matched, matches = matchat(x, (isodd, test1, test2))
+
 @test matches == [view(x, 1:1), view(x, 2:2), view(x, 3:3)]
 
 # at end
@@ -89,18 +94,16 @@ match, matches = matchat(x, (Greed(1, 0:1), anything, Greed(4, 0:1)))
 @test matches[2] == [2, 3]
 @test matches[3] == [4]
 
-
-
 x = [1,2,3,4, 5,5,5, 7, 5,5,5, 8,9]
 
 replaced = matchreplace(x-> (8, 8, 8), x, (Greed(5, 3:3),))
 
 @test replaced ==[1,2,3,4, 8,8,8, 7, 8,8,8, 8,9]
 
-
 x = [1,2,3,4, 5,5,5, 7, 5,5,5, 8,9]
 
 replaced = matchreplace(x-> 7, x, (Greed(5, 3:3),))
 @test replaced ==[1,2,3,4, 7, 7, 7, 8,9]
+
 
 include("expr_match_test.jl")


### PR DESCRIPTION
- updated 'done()' and 'next()' with  'iterate()' and 'firstindex()' to allow compatibility with v0.7+
- added some debugging printing (mostly to compare behaviour with previous version)
- minor reordering with 'export' now on top of the module
- testing of IR now requires "emulating" the LabelNode type, but for the rest the testing is unchanged
- updated Travis & Appveyor to test with Julia 0.7 and latest